### PR TITLE
Comparison releases

### DIFF
--- a/src/core/comparison_releases.py
+++ b/src/core/comparison_releases.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from util.exceptions import ReleasePlannedAndDevelopedOfDifferentSizes
+
+"""The normDiff function performs a vector transformation between the planned release vector and the redeveloped release
+   vector. This transformation represents the quantitative perception of the difference between the planned quality
+   requirement for a release, and the observed result, after its development."""
+
+def normDiff(rp, rd):
+    if len(rp) != len(rd):
+        raise ReleasePlannedAndDevelopedOfDifferentSizes(
+            "The size between planned and developed release vectors is not equal.",
+        )
+    return np.linalg.norm(rp - rd) / np.linalg.norm(rp)
+
+
+"""The diff function interprets a vector transformation between the planned and developed release vectors.
+    It generates a vector that expresses whether the result observed in a release is above or below the planned quality
+    requirement."""
+
+def diff(rp, rd):
+    if len(rp) != len(rd):
+        raise ReleasePlannedAndDevelopedOfDifferentSizes(
+            "The size between planned and developed release vectors is not equal.",
+        )
+    return [max(0, x - y) for x, y in zip(rp, rd)]

--- a/src/core/comparison_releases.py
+++ b/src/core/comparison_releases.py
@@ -2,9 +2,10 @@ import numpy as np
 
 from util.exceptions import ReleasePlannedAndDevelopedOfDifferentSizes
 
-"""The normDiff function performs a vector transformation between the planned release vector and the redeveloped release
-   vector. This transformation represents the quantitative perception of the difference between the planned quality
-   requirement for a release, and the observed result, after its development."""
+"""The normDiff function performs a vector transformation between the planned release vector and the redeveloped
+release vector. This transformation represents the quantitative perception of the difference between the
+planned quality requirement for a release, and the observed result, after its development."""
+
 
 def normDiff(rp, rd):
     if len(rp) != len(rd):
@@ -15,8 +16,9 @@ def normDiff(rp, rd):
 
 
 """The diff function interprets a vector transformation between the planned and developed release vectors.
-    It generates a vector that expresses whether the result observed in a release is above or below the planned quality
-    requirement."""
+It generates a vector that expresses whether the result observed in a release is above or below the planned quality
+requirement."""
+
 
 def diff(rp, rd):
     if len(rp) != len(rd):

--- a/src/util/exceptions.py
+++ b/src/util/exceptions.py
@@ -35,3 +35,8 @@ class InvalidThresholdValue(MeasureSoftGramCoreException):
     """Raised when a invalid threshold value is provided to the interpretation function"""
 
     pass
+
+class ReleasePlannedAndDevelopedOfDifferentSizes(MeasureSoftGramCoreException):
+    """Raised when the sizes of the planned and developed release vectors are different"""
+
+    pass

--- a/src/util/exceptions.py
+++ b/src/util/exceptions.py
@@ -36,6 +36,7 @@ class InvalidThresholdValue(MeasureSoftGramCoreException):
 
     pass
 
+
 class ReleasePlannedAndDevelopedOfDifferentSizes(MeasureSoftGramCoreException):
     """Raised when the sizes of the planned and developed release vectors are different"""
 


### PR DESCRIPTION
# Comparison functions between releases

## Description
Add treatment to perform the quantitive and comparison between releases

## Why it is necessary
Because this treatment is also defined in the measuresoftgram algebraic model

## Acepptance criteria
Not applicable
